### PR TITLE
Feature different room configurations

### DIFF
--- a/control.py
+++ b/control.py
@@ -57,30 +57,37 @@ controls = {'temp': 'temp',
             'blind': 'blind',
             'opdoor': 'door_open'}
 
-defaults = {'door_light': 'OFF',
-            'window_light': 'OFF',
-            'blind': '10',
-            'climate_mode': 'FAN_ONLY',
-            'climate_control': 'OFF',
-            'fanspeed': '100',
-            'temp': '25'}
-
-other_room_conf = {
-    'winter_heat' :
-            {'door_light': 'AUTO',
-            'window_light': 'AUTO',
-            'blind': '80',
-            'climate_mode': 'HEAT',
-            'climate_control': 'ON',
-            'fanspeed': '100',
-            'temp': '23'},
-    'summer_cold' : {'door_light': 'AUTO',
-            'window_light': 'AUTO',
-            'blind': '80',
-            'climate_mode': 'COLD',
-            'climate_control': 'ON',
-            'fanspeed': '100',
-            'temp': '25'}
+room_confs = {
+    'defaults':
+    {
+        'door_light': 'OFF',
+        'window_light': 'OFF',
+        'blind': '10',
+        'climate_mode': 'FAN_ONLY',
+        'climate_control': 'OFF',
+        'fanspeed': '100',
+        'temp': '25'
+    },
+    'winter_heat':
+    {
+        'door_light': 'AUTO',
+        'window_light': 'AUTO',
+        'blind': '80',
+        'climate_mode': 'HEAT',
+        'climate_control': 'ON',
+        'fanspeed': '100',
+        'temp': '23'
+    },
+    'summer_cold':
+    {
+        'door_light': 'AUTO',
+        'window_light': 'AUTO',
+        'blind': '80',
+        'climate_mode': 'COLD',
+        'climate_control': 'ON',
+        'fanspeed': '100',
+        'temp': '25'
+    }
 }
 
 cc_values = ['ON', 'OFF']
@@ -156,28 +163,15 @@ def file_format():
     print "user, password and room, inside the file."
 
 
-def set_default(session, conf=defaults):
-    find  = False
-    if conf != 'defaults':
-        for other_conf in other_room_conf:
-            if other_conf == conf:
-                find  = True
-                print bcolors.HEADER\
-                    + "\t[+] INFO: Setting room with"\
-                    + " '" + conf + "' "\
-                    + "setings:"\
-                    + bcolors.ENDC
-                for confI in other_room_conf[conf]:
-                    set_control(session, confI, other_room_conf[conf][confI])
-        if not find:
-            print bcolors.ERROR\
-                + "\t[-] The configuration room"\
-                + " '" + conf + "' "\
-                + "does not exist."\
-                + bcolors.ENDC
-    else:
-        for dflt in defaults:
-            set_control(session, dflt, defaults[dflt])
+def set_default(session, config):
+    print bcolors.HEADER\
+        + "[++] Setting room with"\
+        + " '" + config + "' "\
+        + "settings"\
+        + bcolors.ENDC
+
+    for dflt in room_confs[config]:
+        set_control(session, dflt, room_confs[config][dflt])
 
 
 def set_control(session, control, value):
@@ -325,9 +319,14 @@ def main(argparser, args):
     if args.state:
         get_current_state(session)
     elif args.default:
-        actions = list_used_options(argparser, args)
-        for act in actions:
-            set_default(session, act[1])
+        if args.default not in room_confs:
+            print bcolors.ERROR\
+                + "\t[-] The configuration room"\
+                + " '" + args.default + "' "\
+                + "does not exist."\
+                + bcolors.ENDC
+        else:
+            set_default(session, args.default)
     else:
         actions = list_used_options(argparser, args)
         for act in actions:
@@ -379,7 +378,7 @@ if __name__ == '__main__':
                        action='store_true')
 
     group.add_argument('-def', '--default',
-                       # nargs='?', const='defaults'
+                       nargs='?', const='defaults',
                        help='Set the room with a preconfigure setings.')
 
     group.add_argument('-t', '--temp',
@@ -428,6 +427,7 @@ if __name__ == '__main__':
         sys.exit()
 
     print bcolors.HEADER\
-        + "[+] Script started"\
+        + "[++] Script started"\
         + bcolors.ENDC
+
     main(argparser, args)

--- a/control.py
+++ b/control.py
@@ -65,6 +65,24 @@ defaults = {'door_light': 'OFF',
             'fanspeed': '100',
             'temp': '25'}
 
+other_room_conf = {
+    'winter_heat' :
+            {'door_light': 'AUTO',
+            'window_light': 'AUTO',
+            'blind': '80',
+            'climate_mode': 'HEAT',
+            'climate_control': 'ON',
+            'fanspeed': '100',
+            'temp': '23'},
+    'summer_cold' : {'door_light': 'AUTO',
+            'window_light': 'AUTO',
+            'blind': '80',
+            'climate_mode': 'COLD',
+            'climate_control': 'ON',
+            'fanspeed': '100',
+            'temp': '25'}
+}
+
 cc_values = ['ON', 'OFF']
 cm_values = ['HEAT', 'COOL', 'FAN_ONLY']
 fs_values = ['25', '50', '75', '100']

--- a/control.py
+++ b/control.py
@@ -156,9 +156,28 @@ def file_format():
     print "user, password and room, inside the file."
 
 
-def set_default(session):
-    for dflt in defaults:
-        set_control(session, dflt, defaults[dflt])
+def set_default(session, conf=defaults):
+    find  = False
+    if conf != 'defaults':
+        for other_conf in other_room_conf:
+            if other_conf == conf:
+                find  = True
+                print bcolors.HEADER\
+                    + "\t[+] INFO: Setting room with"\
+                    + " '" + conf + "' "\
+                    + "setings:"\
+                    + bcolors.ENDC
+                for confI in other_room_conf[conf]:
+                    set_control(session, confI, other_room_conf[conf][confI])
+        if not find:
+            print bcolors.ERROR\
+                + "\t[-] The configuration room"\
+                + " '" + conf + "' "\
+                + "does not exist."\
+                + bcolors.ENDC
+    else:
+        for dflt in defaults:
+            set_control(session, dflt, defaults[dflt])
 
 
 def set_control(session, control, value):
@@ -306,7 +325,9 @@ def main(argparser, args):
     if args.state:
         get_current_state(session)
     elif args.default:
-        set_default(session)
+        actions = list_used_options(argparser, args)
+        for act in actions:
+            set_default(session, act[1])
     else:
         actions = list_used_options(argparser, args)
         for act in actions:
@@ -358,8 +379,8 @@ if __name__ == '__main__':
                        action='store_true')
 
     group.add_argument('-def', '--default',
-                       help='Set the default values.',
-                       action='store_true')
+                       # nargs='?', const='defaults'
+                       help='Set the room with a preconfigure setings.')
 
     group.add_argument('-t', '--temp',
                        help='Set the temperature.')


### PR DESCRIPTION
Fixed #8

# Create other rooms configurations
```
room_confs = {
    'defaults':
    {
        'door_light': 'OFF',
        'window_light': 'OFF',
        'blind': '10',
        'climate_mode': 'FAN_ONLY',
        'climate_control': 'OFF',
        'fanspeed': '100',
        'temp': '25'
    },
    'winter_heat':
    {
        'door_light': 'AUTO',
        'window_light': 'AUTO',
        'blind': '80',
        'climate_mode': 'HEAT',
        'climate_control': 'ON',
        'fanspeed': '100',
        'temp': '23'
    },
    'summer_cold':
    {
        'door_light': 'AUTO',
        'window_light': 'AUTO',
        'blind': '80',
        'climate_mode': 'COLD',
        'climate_control': 'ON',
        'fanspeed': '100',
        'temp': '25'
    }
}
```
# Pass the room configuration to `-def` option
Without argument (`./control.py -def`), take the "defaults" room configuration.
```
  -def [DEFAULT], --default [DEFAULT]
                        Set the room with a preconfigure setings.
```
